### PR TITLE
[2.2] - Support experimental Paper builds

### DIFF
--- a/platform/spigot/src/main/java/me/lucaaa/advancedlinks/spigot/managers/PlatformManager.java
+++ b/platform/spigot/src/main/java/me/lucaaa/advancedlinks/spigot/managers/PlatformManager.java
@@ -16,6 +16,7 @@ import org.bukkit.ServerLinks;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import java.util.Arrays;
 import java.util.logging.Level;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -75,10 +76,12 @@ public class PlatformManager {
     }
 
     public void registerMainCommand() {
-        String[] versionParts = plugin.getServer().getBukkitVersion().split("-")[0].split("\\.");
-        int major = Integer.parseInt(versionParts[1]);
-        int minor = (versionParts.length > 2) ? Integer.parseInt(versionParts[2]) : 0;
+        String[] versionParts = Arrays.stream(plugin.getServer().getBukkitVersion().split("-")[0].split("\\."))
+                .filter(part -> part.matches("\\d+")) // Keep only numeric parts, experimental Paper versions contain non-numeric values (e.g. "build")
+                .toArray(String[]::new);
         boolean oldVersioning = Integer.parseInt(versionParts[0]) == 1;
+        int major = Integer.parseInt(versionParts[1]);
+        int minor = (oldVersioning && versionParts.length > 2) ? Integer.parseInt(versionParts[2]) : 0;
 
         if (platform == Platform.SPIGOT || (oldVersioning && major <= 21 && minor < 4)) {
             new SpigotMainCommand(plugin);


### PR DESCRIPTION
Fixes a crash when running experimental Paper builds, caused by these versions containing the build number, which cannot currently be parsed. 

See example below, encountered when using this plugin in our Staging setup for 26.2 with the `paper-api-26.2.build.29-alpha.jar`:
```
[15:10:07 INFO]: [AL] Enabling AdvancedLinks v2.1.1
[15:10:07 INFO]: [AL] Detected platform: Paper. Enabling support...
[15:10:07 ERROR]: Error occurred while enabling AdvancedLinks v2.1.1 (Is it up to date?)
java.lang.NumberFormatException: For input string: "build"
        at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67) ~[?:?]
        at java.base/java.lang.Integer.parseInt(Integer.java:565) ~[?:?]
        at java.base/java.lang.Integer.parseInt(Integer.java:662) ~[?:?]
        at AdvancedLinks-plugin-2.1.1.jar//me.lucaaa.advancedlinks.spigot.managers.PlatformManager.registerMainCommand(PlatformManager.java:80) ~[?:?]
        at AdvancedLinks-plugin-2.1.1.jar//me.lucaaa.advancedlinks.SpigotAdvancedLinks.onEnable(SpigotAdvancedLinks.java:67) ~[?:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:279) ~[paper-api-26.2.build.29-alpha.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:207) ~[paper-26.2.jar:26.2-29-bb32c37]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[paper-26.2.jar:26.2-29-bb32c37]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520) ~[paper-api-26.2.build.29-alpha.jar:?]
        at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:633) ~[paper-26.2.jar:26.2-29-bb32c37]
        at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:590) ~[paper-26.2.jar:26.2-29-bb32c37]
        at net.minecraft.server.MinecraftServer.initPostWorld(MinecraftServer.java:672) ~[paper-26.2.jar:26.2-29-bb32c37]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:343) ~[paper-26.2.jar:26.2-29-bb32c37]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1290) ~[paper-26.2.jar:26.2-29-bb32c37]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:302) ~[paper-26.2.jar:26.2-29-bb32c37]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
[15:10:07 INFO]: [AL] Disabling AdvancedLinks v2.1.1
```

I've not bumped the versioning further in this PR, as it looks like you are yet to publish AdvancedLinks 2.2